### PR TITLE
164471444 Refactor push notification subscriptions

### DIFF
--- a/app.py
+++ b/app.py
@@ -20,18 +20,19 @@ def create_app(config_name):
     def index():
         return render_template('index.html')
 
-    @app.route("/notifications", methods=['POST', 'GET'])
-    def calendar_notifications():
-        PushNotification().send_notifications_to_subscribers()
+    @app.route("/notifications/<string:subscriber_key>", methods=['POST', 'GET'])
+    def calendar_notifications(subscriber_key):
+        PushNotification().send_notifications_to_subscribers(subscriber_key)
         return PushNotification.send_notifications(PushNotification)
 
     @app.route("/channels", methods=['POST', 'GET'])
     def create_channels():
         return PushNotification.create_channels(PushNotification)
 
-    @app.route("/refresh", methods=['POST', 'GET'])
+    @app.route("/refresh", methods=['POST'])
     def refresh():
-        return PushNotification.refresh(PushNotification)
+        subscriber_key = request.args.to_dict().get('subscriber_key')
+        return PushNotification().refresh(subscriber_key=subscriber_key)
 
     @app.route("/get_notifications", methods=['GET'])
     def get_notifications():
@@ -40,7 +41,8 @@ def create_app(config_name):
     @app.route("/subscription", methods=['POST', 'GET'])
     def subscribe():
         if request.method == "GET":
-            return Response(response=json.dumps({"public_key": vapid_public_key}),
+            return Response(response=json.dumps(
+                        {"public_key": vapid_public_key}),
                             headers={"Access-Control-Allow-Origin": "*"},
                             content_type="application/json"
                             )


### PR DESCRIPTION
#### What does this PR do?
Refactor push notification subscriptions

#### Description of Task to be completed?
Refactor the subscription endpoint to allow the subscriber to add an endpoint where Calendar IDs can be gotten. Subscriber should also add an endpoint to be called when a push notification is received.

#### Type of change
feature(Refactor push notification subscriptions)

#### How should this be manually tested?
git pull the branch `ft-refactor-push-notification-164795678`
create a subscriber as shown below:
````
{
"subscriber_info":{
"platform": "graphql",
"subscription_info":"endpoint_to_hit.com",
"calendar_ids_endpoint":"{ allRooms { rooms { calendarId, firebaseToken } } }"
}
}
````
hit the refresh enpoint to below. 
`http://127.0.0.1:5000/refresh`
It should be able to populate the push-notification database with calender ids from the converge database.
To update the calendar ids for a single subscriber pass a URL the subscriber_key on the refresh endpoint as shown below.
`http://127.0.0.1:5000/refresh?subscriber_key=4994c760-c1ed-4d94-a370-687cb95e8825`
#### Screenshots
creating a subscriber
![image](https://user-images.githubusercontent.com/39625835/55093977-84024a00-50c6-11e9-8f17-2c3b42766411.png)
refreshing a specific subscriber's calender_ids
![image](https://user-images.githubusercontent.com/39625835/55094057-ab591700-50c6-11e9-91c5-7966ee2b04a6.png)
#### What are the relevant pivotal tracker stories?
[#164471444](https://www.pivotaltracker.com/story/show/164795678)