### PR TITLE
CON-255 manual refresh and create channel endpoint endpoints

### DIFF
--- a/app.py
+++ b/app.py
@@ -27,11 +27,11 @@ def create_app(config_name):
 
     @app.route("/channels", methods=['POST', 'GET'])
     def create_channels():
-        return PushNotification.create_channels(PushNotification)
+        return PushNotification.manual_create_channels(PushNotification)
 
     @app.route("/refresh", methods=['POST', 'GET'])
     def refresh():
-        return PushNotification.refresh(PushNotification)
+        return PushNotification.manual_refresh(PushNotification)
 
     @app.route("/token", methods=['POST', 'GET'])
     def update_firebase_token():
@@ -57,7 +57,7 @@ def create_app(config_name):
     @app.route("/googledb635995d37deb01.html", methods=['GET'])
     def verify_push_url():
         return render_template("googledb635995d37deb01.html")
-    
+
     @app.route("/delete_room", methods=['DELETE'])
     def delete_room():
         calendar_id = request.args.get('calendar_id')

--- a/service/push_notification.py
+++ b/service/push_notification.py
@@ -124,9 +124,9 @@ class PushNotification():
             return
 
     def manual_create_channels(self):
-        PushNotification().channels()
+        self.channels(self)
         data = {
-            "message": "Channels added successfully"
+            "message": "Channels created"
         }
         response = jsonify(data)
         return response
@@ -147,6 +147,7 @@ class PushNotification():
             result['results'] = results['results']
             result['subscriber_info'] = selected_calendar['firebase_token']
             result['platform'] = 'android'
+            result['calendar_id'] = selected_calendar['calendar_id']
             save_to_db(result)
 
         # Send an update to the backend API

--- a/templates/log.html
+++ b/templates/log.html
@@ -30,10 +30,11 @@
       
       <table>
         <tr>
-          <th>Results</th>
-          <th>Platform</th>
           <th>Time</th>
+          <th>Results</th>
           <th>Subscriber Info</th>
+          <th>Platform</th>
+          <th>Calendar_id</th>
 
 
           

--- a/utilities/utility.py
+++ b/utilities/utility.py
@@ -28,11 +28,12 @@ def save_to_db(*args):
     result = results[0]
     key = len(db.keys('*Notification*')) + 1
     result['time'] = datetime.datetime.now().replace(
-                second=0, microsecond=0
-            )
+        second=0, microsecond=0
+    )
     notification_details = {'time': str(result['time']),
                             'results': str(result['results']),
                             'subscriber_info': str(result['subscriber_info']),
-                            'platform': str(result['platform'])
+                            'platform': str(result['platform']),
+                            'calendar_id': str(result['calendar_id'])
                             }
     db.hmset('Notification:' + str(key), notification_details)


### PR DESCRIPTION
#### Description
This Pull request enables a user to manually refresh and create channels. Previously, we only had an automated way of doing that. The pull request also adds a calendar_id column on `/get_notifications`

#### Type of Change
Added manual endpoints for refresh and channels.
Added calendar_id column to push notification logs 
#### How has this been tested
- [x] End to end testing
- [x] Integration tests


#### How should this be manually tested?
1. Clone the repo: `git clone https://github.com/andela/mrm_push.git`
2. Setup project according to Readme.md
3. checkout to branch `story/CON-255-manual-refresh-channel-endpoint `
4. Run `/channels` and `/refresh` on insomnia or postman. The two endpoints should work.
6. On the browser, go tho the route `get_notifications`. You will see the added calendar id column which will be containing the calendar id of each notification.

#### Checklist
- [x] My changes generate no new warnings
- [x] My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [x] Existing unit tests pass locally with my changes
- [x] Implementation works according to expectations



#### JIRA
[CON-255](https://andela-apprenticeship.atlassian.net/browse/CON-255)
