### PR TITLE
CV3-55 make notifications calls run on celery.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,9 @@ html_coverage_report/
 # credentials
 credentials.json
 
+# binary file where snapshots saved
+dump.rdb
+
 #logs
 service.err.log
 service.out.log

--- a/app.py
+++ b/app.py
@@ -1,10 +1,11 @@
-from flask import Flask, render_template, request, Response
+from flask import Flask, render_template, request, Response, jsonify
 from flask_json import FlaskJSON
 from flask_cors import CORS
 from config import config
 from service.push_notification import PushNotification
 import os
 import json
+
 
 vapid_public_key = os.getenv("VAPID_PUBLIC_KEY")
 
@@ -23,7 +24,9 @@ def create_app(config_name):
     @app.route("/notifications", methods=['POST', 'GET'])
     def calendar_notifications():
         PushNotification().send_notifications_to_subscribers()
-        return PushNotification.send_notifications(PushNotification)
+        result = PushNotification.send_notifications(PushNotification)
+        return result
+
 
     @app.route("/channels", methods=['POST', 'GET'])
     def create_channels():

--- a/service/external_calls_notification.py
+++ b/service/external_calls_notification.py
@@ -1,0 +1,67 @@
+import requests
+import os
+import json
+
+from flask import Flask
+from pyfcm import FCMNotification
+
+from config import config
+from utilities.utility import save_to_db
+import celery
+
+config_name = os.getenv('APP_SETTINGS')
+push_service = FCMNotification(api_key=os.getenv('FCM_API_KEY'))
+api_token = os.getenv('USER_TOKEN')
+
+notification_url = config.get(config_name).NOTIFICATION_URL
+url = config.get(config_name).CONVERGE_MRM_URL
+app = Flask(__name__)
+
+
+class ExternalCallsNotifications():
+    #notify a single device and save notifications
+    @celery.task(name='push_notification-single-device')
+    def notify_device(firebase_token, calendar_id):
+        try:
+            results = push_service.notify_single_device(
+                registration_id = firebase_token,
+                message_body="success")
+            result = {}
+            result['results'] = results['results']
+            result['subscriber_info'] = firebase_token
+            result['platform'] = 'android'
+            result['calendar_id'] = calendar_id
+            save_to_db(result)
+            return results
+        except Exception as error:
+            results = error
+            result = {}
+            result['results'] = results
+            result['subscriber_info'] = firebase_token
+            result['platform'] = 'android'
+            result['calendar_id'] = calendar_id
+            save_to_db(result)
+            return error
+
+     
+    #update the backend API method
+    @celery.task(name='push_notification-update-backend')
+    def update_backend(calendar_id):
+        try:
+            notify_api_mutation = (
+                {
+                    'query':
+                        """
+                        mutation {
+                            mrmNotification ( calendarId: \"%s\" ) {
+                                message
+                            }
+                        }
+                        """ % calendar_id
+                }
+            )
+            headers = {'Authorization': 'Bearer %s' % api_token}
+            requests.post(url=url, json=notify_api_mutation, headers=headers)
+        except Exception as error:
+            return error    
+

--- a/templates/log.html
+++ b/templates/log.html
@@ -29,23 +29,23 @@
       <h2>Push Notification Logs</h2>
       
       <table>
-        <tr>
-          <th>Time</th>
-          <th>Results</th>
-          <th>Subscriber Info</th>
-          <th>Platform</th>
-          <th>Calendar_id</th>
-
-
-          
-        </tr>
-          {% for item in result%}
           <tr>
-            {% for value in item.values() %}
-              <td>{{value}}</td>
-            {% endfor %}
-          </tr>
-          {% endfor %}
+              <th>Time</th>
+              <th>Results</th>
+              <th>Subscriber Info</th>
+              <th>Platform</th>
+              <th>Calendar_id</th>
+    
+    
+              
+            </tr>
+              {% for item in result%}
+              <tr>
+                {% for value in item.values() %}
+                  <td>{{value}}</td>
+                {% endfor %}
+              </tr>
+              {% endfor %}
       </table>
       
       </body>


### PR DESCRIPTION
## Description ##
This pull request makes notifications calls run on celery.

## How can This be tested ##
- Clone the repo: `git clone https://github.com/andela/mrm_push.git`
- Setup project according to `Readme.md`
- checkout to branch `story/CV3-55-celery-notification-calls`
- Run celery `celery worker -A cworker.celery --loglevel=info`
- to get notifications, hit the endpoint `http://127.0.0.1:5000/notifications`

## Type of change ##
Please select the relevant option
- [ ] Bugfix(a non-breaking change which fixes an issue)
- [x] New feature(a non-breaking change which adds functionality)
- [ ] Breaking change(fix of a feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist: ##
- [x] My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes

## JIRA ##
[CV3-55](https://andela-apprenticeship.atlassian.net/browse/CV3-55?atlOrigin=eyJpIjoiMGU5NzQ5NjY2YWI5NDJlZDhhMmNhYmZjYTU1ZDVlNzciLCJwIjoiaiJ9)

