### PR TITLE
CV3-70 implement delete bouquet

### DIFF
--- a/api/v2/controllers/bouquets/bouquets_controller.py
+++ b/api/v2/controllers/bouquets/bouquets_controller.py
@@ -1,7 +1,7 @@
 from flask import make_response, jsonify, request
 from flask_restful import Resource
 
-from api.v2.helpers.bouquets.bouquets_helper import query_all_bouquets
+from api.v2.helpers.bouquets.bouquets_helper import query_all_bouquets, query_bouquet
 from api.v2.models.bouquets.bouquets_model import Bouquets as BouquetsModel
 from api.v2.utilities.validators import validate_bouquet_adding
 from api.v2.helpers.credentials import check_bouquet_credentials
@@ -33,3 +33,14 @@ class Bouquets(Resource):
                                   refresh_token=credentials['refresh_token'])
         return make_response(jsonify({'data': {'message': 'successfully added bouquet',
                                                'bouquet': data}}), 201)
+    
+    def delete(self):
+        bouquet_id = request.args['bouquet_id']
+        if not bouquet_id.isdigit():
+            return make_response(jsonify({'message': 'The bouquet id should be an integer. Try again'}), 400)
+        bouquet = query_bouquet(bouquet_id)
+        if not bouquet:
+            return make_response(jsonify({'message': 'The bouquet you want to delete is not found'}), 404)
+        BouquetsModel.delete_bouquet(BouquetsModel, bouquet_id)
+        return make_response(jsonify({'message': 'The bouquet was deleted successfully'}), 200)             
+        

--- a/api/v2/helpers/bouquets/bouquets_helper.py
+++ b/api/v2/helpers/bouquets/bouquets_helper.py
@@ -9,3 +9,9 @@ def query_all_bouquets():
         bouquets = BouquetsSchema(many=True).dump(all_bouquets)
 
     return bouquets
+    
+def query_bouquet(bouquet_id):
+    bouquet = BouquetsModel.query.filter_by(id=bouquet_id).first()
+    if bouquet:
+        return BouquetsSchema(many=False).dump(bouquet)
+    return None

--- a/api/v2/models/bouquets/bouquets_model.py
+++ b/api/v2/models/bouquets/bouquets_model.py
@@ -49,12 +49,11 @@ class Bouquets(Base, Utility):
         bouquet = Bouquets(**kwargs)
         bouquet.save()
 
-        # TODO: add functionality to add a bouquet on the bouquet table
-
     def delete_bouquet(self, bouquet_id):
         """Method for deleting a bouquet"""
 
-        # TODO: add functionality to remove a listed bouquet from the bouquet table
+        result = self.query.filter_by(id=bouquet_id).first()
+        self.delete(result) 
 
     def add_calendar_to_bouquet(self, calendar_id, bouquet_id):
         """Method for adding a calendar to a bouquet"""

--- a/manage.py
+++ b/manage.py
@@ -1,6 +1,7 @@
 import os
 
 from flask_script import Manager, Shell
+from flask import make_response, jsonify
 
 # local imports
 from app import create_app  # noqa: E402
@@ -17,6 +18,11 @@ manager.add_command(
     "shell", Shell(
         make_context=make_shell_context))
 
+@app.errorhandler(404)
+def route_not_found(e):
+    return make_response(jsonify({
+        "error": 'The URL was not found. Please check your spelling and try again'
+        }), 404)
 
 if __name__ == '__main__':
     manager.run()

--- a/tests/test_bouquets/test_bouquets.py
+++ b/tests/test_bouquets/test_bouquets.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 from tests.base import BaseTestCase
 
+from api.v2.controllers.bouquets.bouquets_controller import Bouquets
 
 class TestBouquets(BaseTestCase):
     def test_get_all_bouquets(self):
@@ -55,3 +56,21 @@ class TestBouquets(BaseTestCase):
 
         self.assertEqual(response.status_code, 500)
         self.assertEqual(re['error'], 'failed to add bouquet')
+        
+    def test_delete_bouquet(self):
+        # Should return 404 when a bouquets is not found
+        response = self.app_test.delete("/v2/bouquets?bouquet_id=100")
+        self.assertTrue(b"The bouquet you want to delete is not found" in response.data)
+        self.assertEqual(response.status_code, 404)
+
+    def test_delete_bouquet_correctly(self):
+        # Should return 200 when a bouquet was deleted
+        response = self.app_test.delete("/v2/bouquets?bouquet_id=1")
+        self.assertTrue(b"The bouquet was deleted successfully" in response.data)
+        self.assertEqual(response.status_code, 200)
+
+    def test_delete_bouquet_with_invalid_id(self):
+        # Should return 400 when a bouquet_id is not integer
+        response = self.app_test.delete("/v2/bouquets?bouquet_id=mmm")
+        self.assertTrue(b"The bouquet id should be an integer. Try again" in response.data)
+        self.assertEqual(response.status_code, 400)


### PR DESCRIPTION
## Description ##
This pull request makes possible for a user to delete a bouquet.

## How can This be tested ##
- Clone the repo: `git clone https://github.com/andela/mrm_push.git`
- Setup project according to `Readme.md`
- checkout to branch `story/CV3-70-implement-delete-bouquet`
- to delete a bouquet, hit the endpoint `http://127.0.0.1:5000/v2/bouquets?bouquet_id=?`

## Type of change ##
Please select the relevant option
- [ ] Bugfix(a non-breaking change which fixes an issue)
- [x] New feature(a non-breaking change which adds functionality)
- [ ] Breaking change(fix of a feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist: ##
- [x] My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

## JIRA ##
[CV3-70](https://andela-apprenticeship.atlassian.net/browse/CV3-70?atlOrigin=eyJpIjoiNzI0ZDliNDBlYzg5NDBlMDljZjVhNGY5YWRhMzgwNDciLCJwIjoiaiJ9)

