### PR TITLE
CV3-73 register bouquet channels

### DIFF
--- a/api/v2/__init__.py
+++ b/api/v2/__init__.py
@@ -1,7 +1,8 @@
 from flask_restful import Api
 from flask import Blueprint
 
-from api.v2.controllers.channels.channels_controller import Channels
+from api.v2.controllers.channels.channels_controller import (Channels,
+                                                             WatchChannels)
 from api.v2.controllers.bouquets.bouquets_controller import Bouquets
 from api.v2.controllers.logs.logs_controller import Logs
 
@@ -14,5 +15,6 @@ mrm_push = Api(api_v2)
 """Add mrm push resources"""
 
 mrm_push.add_resource(Channels, '/channels', strict_slashes=False)
+mrm_push.add_resource(WatchChannels, '/channels/register', strict_slashes=False)
 mrm_push.add_resource(Bouquets, '/bouquets', strict_slashes=False)
 mrm_push.add_resource(Logs, '/logs', strict_slashes=False)

--- a/api/v2/controllers/channels/channels_controller.py
+++ b/api/v2/controllers/channels/channels_controller.py
@@ -6,7 +6,9 @@ from flask_restful import Resource, request
 from googleapiclient.errors import HttpError
 
 from api.v2.helpers.credentials import check_bouquet_credentials
-from api.v2.helpers.channels.channels_helper import query_all_channels
+from api.v2.helpers.channels.channels_helper import (
+                                                query_all_channels,
+                                                get_channels)
 from api.v2.models.channels.channels_model import Channels as channels_model
 from api.v2.helpers.bouquets.bouquets_helper import query_bouquet
 from api.v2.utilities.validators import validate_calendar_info
@@ -67,6 +69,57 @@ class Channels(Resource):
         except HttpError as err:
             if err.resp.status == 404:
                 return {'error': 'calendar not found'}, err.resp.status
+            return {'error': err._get_reason()}, err.resp.status
+
+        except Exception:
+            return {'error': 'server error! please try again later'}, 500
+
+
+class WatchChannels(Resource):
+    def post(self):
+        # Endpoint to register channels/calendars with the Google Calendar API
+        # to receive notifications
+        try:
+            bouquet_id = request.args['bouquet_id']
+            if not bouquet_id.isdigit():
+                return {'error': 'bouquet_id should be an integer'}, 400
+
+            bouquet = query_bouquet(bouquet_id)
+            if not bouquet:
+                return {'error': f"bouquet with id={bouquet_id} doesn't exist"}, 404
+
+            channels = get_channels(bouquet_id)
+            if not channels:
+                return {'error': 'no channels/calendars found in the provided bouquet'}, 404
+
+            bouquet_credentials = check_bouquet_credentials(bouquet)
+            service = bouquet_credentials['service']
+
+            for channel in channels:
+                # stop the channel from being watched
+                service.channels().stop(body={
+                                 "id": channel['channel_id'],
+                                 "resourceId": channel['resource_id']
+                            }).execute()
+
+                # watch the channel for any changes
+                event = service.events().watch(
+                        calendarId=channel['calendar_id'], body={
+                            'id': str(uuid.uuid1()),
+                            'type': 'web_hook',
+                            'address': os.getenv('NOTIFICATION_URL')
+                        }).execute()
+
+                # update channel to the current channel which is being watched
+                _channel = channels_model.update_channel(
+                        calendar_id=channel['calendar_id'],
+                        channel_id=event['id'],
+                        resource_id=event['resourceId'],
+                        )
+                if _channel:
+                    return make_response(jsonify({'channels': channels}), 200)
+
+        except HttpError as err:
             return {'error': err._get_reason()}, err.resp.status
 
         except Exception:

--- a/api/v2/helpers/channels/channels_helper.py
+++ b/api/v2/helpers/channels/channels_helper.py
@@ -9,3 +9,11 @@ def query_all_channels():
         channels = ChannelsSchema(many=True).dump(all_channels)
 
     return channels
+
+
+def get_channels(bouquet_id):
+    channels = ChannelsModel.query.filter_by(bouquet_id=bouquet_id).all()
+    if channels:
+        return ChannelsSchema(many=True).dump(channels)
+
+    return None

--- a/api/v2/models/channels/channels_model.py
+++ b/api/v2/models/channels/channels_model.py
@@ -1,10 +1,10 @@
 from sqlalchemy import (Column, String, Integer, Enum, ForeignKey)
 from sqlalchemy.schema import Sequence
+from sqlalchemy.exc import IntegrityError
 
+from api.v2.helpers.database import db_session
 from api.v2.helpers.database import Base
 from api.v2.utilities.utility import Utility, StateType
-from sqlalchemy.exc import IntegrityError
-from api.v2.helpers.database import db_session
 
 
 class Channels(Base, Utility):
@@ -37,3 +37,12 @@ class Channels(Base, Utility):
             db_session.rollback()
 
         return channel_saved
+
+    @staticmethod
+    def update_channel(**kwargs):
+        channel = Channels.query.filter_by(calendar_id=kwargs['calendar_id']).first()
+        channel.channel_id = kwargs['channel_id']
+        channel.resource_id = kwargs['resource_id']
+        db_session.commit()
+
+        return channel


### PR DESCRIPTION
## Description ##
Given a bouquet ID, all the channels/calendars in that bouquet should be registered with the Google Calendar API and be ready to receive notifications.

## Type of change ##
Please select the relevant option
- [ ] Bugfix(a non-breaking change which fixes an issue)
- [x] New feature(a non-breaking change which adds functionality)
- [ ] Breaking change(fix of a feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How can This be tested ##
- Clone the repo: `git clone https://github.com/andela/mrm_push.git`
- Setup project according to `README.md`
- checkout to `story/CV3-73-register-bouquet-channels` branch
- Activate the `virtualenv`

- NB: make sure to update your `NOTIFICATION_URL` value in `.env` to reflect a google verified domain for notifications
 ## run the app
```
$ python manage.py runserver
```
- Make a `POST` request using postman on `http://127.0.0.1:5000/v2/channels/register?bouquet_id=<bouquet_id>`

## Running tests
```
$ pytest -v --cov
```
## Checklist: ##
- [x] My code follows the style guidelines of this project
- [x] I have linted my code prior to submission
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

## JIRA ##
[CV3-73](https://andela-apprenticeship.atlassian.net/browse/CV3-73?atlOrigin=eyJpIjoiMDYzZGVlMGNiMWI1NDFlYmIxZWI4MThmZWQ3OGQwZjUiLCJwIjoiaiJ9)

